### PR TITLE
Update notification settings for Frigate vision automations

### DIFF
--- a/frigate_vision.yaml
+++ b/frigate_vision.yaml
@@ -413,7 +413,7 @@ actions:
               clickAction: '{{ clip_url }}'
               push:
                 interruption-level: active
-              alert_once: '{{ alert_once }}'
+              alert_once: true
               actions:
                 - action: URI
                   title: View Clip
@@ -528,7 +528,7 @@ actions:
                             clickAction: '{{ clip_url }}'
                             push:
                               interruption-level: passive
-                            alert_once: '{{ alert_once }}'
+                            alert_once: true
                             actions:
                               - action: URI
                                 title: View Clip
@@ -669,7 +669,7 @@ actions:
               clickAction: '{{ clip_url }}'
               push:
                 interruption-level: passive
-              alert_once: '{{ alert_once }}'
+              alert_once: true
               actions:
                 - action: URI
                   title: View Clip

--- a/frigate_vision.yaml
+++ b/frigate_vision.yaml
@@ -527,7 +527,7 @@ actions:
                             image: '{{ base_url }}/api/frigate/notifications/{{ id }}/thumbnail.jpg?format=android'
                             clickAction: '{{ clip_url }}'
                             push:
-                              interruption-level: active
+                              interruption-level: passive
                             alert_once: '{{ alert_once }}'
                             actions:
                               - action: URI
@@ -668,7 +668,7 @@ actions:
                 {{ base_url }}/api/frigate/notifications/{{ id }}/{{ 'snapshot' if input_notification_image == 'snapshot' else 'thumbnail' }}.jpg?format=android
               clickAction: '{{ clip_url }}'
               push:
-                interruption-level: active
+                interruption-level: passive
               alert_once: '{{ alert_once }}'
               actions:
                 - action: URI


### PR DESCRIPTION
## Summary
Updated notification behavior in Frigate vision automations by standardizing alert settings and adjusting interruption levels for better user experience.

## Key Changes
- Changed `alert_once` from dynamic template variable `'{{ alert_once }}'` to hardcoded `true` across all notification actions
- Updated interruption levels for certain notifications from `active` to `passive` to reduce notification intrusiveness:
  - Event notification with thumbnail (line 530)
  - Custom notification template (line 671)
- Kept interruption level as `active` for the primary clip notification (line 415)

## Implementation Details
These changes ensure that:
1. Notifications will only alert once per event, preventing duplicate alerts
2. Secondary/custom notifications use passive interruption level to avoid excessive interruptions while maintaining visibility
3. Primary clip notifications retain active interruption level for important events

https://claude.ai/code/session_016u4dqFiUwTSmGegwuHzKRg