### PR TITLE
Fix collage step hanging on ffmpeg stdin

### DIFF
--- a/extract_frigate_frames.sh
+++ b/extract_frigate_frames.sh
@@ -46,8 +46,8 @@ T3=$((DURATION * 80 / 100))
 echo "Duration: $DURATION  |  Frames at: $T1s  $T2s  $T3s"
 
 # Extract frames
-ffmpeg -y -ss "$T1" -i "$CLIP_URL" -vframes 1 "$OUTPUT_DIR/${EVENT_ID}_1.jpg"
-ffmpeg -y -ss "$T2" -i "$CLIP_URL" -vframes 1 "$OUTPUT_DIR/${EVENT_ID}_2.jpg"
-ffmpeg -y -ss "$T3" -i "$CLIP_URL" -vframes 1 "$OUTPUT_DIR/${EVENT_ID}_3.jpg"
+ffmpeg -nostdin -y -ss "$T1" -i "$CLIP_URL" -vframes 1 "$OUTPUT_DIR/${EVENT_ID}_1.jpg"
+ffmpeg -nostdin -y -ss "$T2" -i "$CLIP_URL" -vframes 1 "$OUTPUT_DIR/${EVENT_ID}_2.jpg"
+ffmpeg -nostdin -y -ss "$T3" -i "$CLIP_URL" -vframes 1 "$OUTPUT_DIR/${EVENT_ID}_3.jpg"
 
 echo "Done — frames saved to $OUTPUT_DIR"

--- a/frigate_collage.sh
+++ b/frigate_collage.sh
@@ -104,10 +104,10 @@ echo "Extracting frames at: $T1  $T2  $T3  $T4"
 
 # -update 1 is required in ffmpeg 6+ when writing a single image to a
 # non-patterned filename (e.g. foo.jpg instead of foo_%03d.jpg)
-ffmpeg -y -ss "$T1" -i "$LOCAL_CLIP" -frames:v 1 -update 1 "$FRAME1"
-ffmpeg -y -ss "$T2" -i "$LOCAL_CLIP" -frames:v 1 -update 1 "$FRAME2"
-ffmpeg -y -ss "$T3" -i "$LOCAL_CLIP" -frames:v 1 -update 1 "$FRAME3"
-ffmpeg -y -ss "$T4" -i "$LOCAL_CLIP" -frames:v 1 -update 1 "$FRAME4"
+ffmpeg -nostdin -y -ss "$T1" -i "$LOCAL_CLIP" -frames:v 1 -update 1 "$FRAME1"
+ffmpeg -nostdin -y -ss "$T2" -i "$LOCAL_CLIP" -frames:v 1 -update 1 "$FRAME2"
+ffmpeg -nostdin -y -ss "$T3" -i "$LOCAL_CLIP" -frames:v 1 -update 1 "$FRAME3"
+ffmpeg -nostdin -y -ss "$T4" -i "$LOCAL_CLIP" -frames:v 1 -update 1 "$FRAME4"
 
 test -f "$FRAME1"
 test -f "$FRAME2"
@@ -134,7 +134,7 @@ label_frame() {
     return
   fi
 
-  ffmpeg -y -i "$SRC" \
+  ffmpeg -nostdin -y -i "$SRC" \
     -vf "drawbox=x=10:y=10:w=iw-20:h=60:color=black@0.65:t=fill,\
 drawtext=fontfile='${FONT}':text='${LABEL}':x=20:y=20:fontsize=28:fontcolor=white" \
     -update 1 "$DST"
@@ -149,7 +149,7 @@ echo "Labels added"
 
 # ── 2×2 collage ───────────────────────────────────────────────────────────
 # scale=-2 (not -1) ensures dimensions stay even-numbered for jpeg encoding
-ffmpeg -y \
+ffmpeg -nostdin -y \
   -i "$LABELED1" \
   -i "$LABELED2" \
   -i "$LABELED3" \


### PR DESCRIPTION
## Summary
- The automation was stalling indefinitely at the "Build collage if enabled" (`shell_command.frigate_build_collage`) step.
- Cause: Home Assistant's `shell_command` integration launches `ffmpeg` without a real TTY but leaves stdin open, and `ffmpeg` by default tries to read interactive control input from stdin. With no terminal to signal EOF, `ffmpeg` blocks forever waiting for input that never arrives, hanging the whole automation (the shell command never returns).
- Fix: added `-nostdin` to every `ffmpeg` invocation so it never attempts to read from stdin.

## Key changes
- `frigate_collage.sh`: added `-nostdin` to the 4 frame-extraction calls, the `label_frame` labeling call, and the final collage-assembly call.
- `extract_frigate_frames.sh`: added `-nostdin` to its 3 frame-extraction calls for consistency, since it's a documented alternative script.

## Test plan
- [ ] Enable "Use Multi-Frame Collage" and trigger a Frigate event; confirm the collage step completes instead of hanging.
- [ ] Confirm the collage image is produced and used by the AI analysis step as before.

https://claude.ai/code/session_01WFyoPMkXcyxQhgaSURP9UA


---
_Generated by [Claude Code](https://claude.ai/code/session_01WFyoPMkXcyxQhgaSURP9UA)_