### PR TITLE
Ground AI analysis with Frigate detected zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - **🚨 Listens for Frigate detection events** from any camera via MQTT
 - **🧠 Analyses snapshots with AI** using Home Assistant's `ai_task` domain — works with Ollama, OpenAI, Google, and any other provider you have configured
 - **📸 Optional multi-frame collage** — extracts 4 frames from the event clip and feeds them to the AI for richer temporal context
+- **📍 Zone-grounded analysis** — passes Frigate's detected zones (`entered_zones`/`current_zones`) into the AI prompt as authoritative location data, so the model describes where the subject actually was instead of guessing
 - **🕒 Per-camera cooldowns** to prevent notification spam
 - **📱 Instant + enriched notifications** — a fast initial push fires immediately, then a second enriched notification follows once AI analysis is complete
 - **🔔 Multi-device support** — send to one or more phones/tablets simultaneously

--- a/frigate_vision.yaml
+++ b/frigate_vision.yaml
@@ -628,6 +628,23 @@ actions:
           camera: '{{ camera }}'
       - delay: '00:00:05'
 
+  # ── Collect Frigate zones for AI grounding ────────────────────────────────
+  # entered_zones is cumulative over the event, so merge the freshest loop
+  # payload (persists after the loop, like sub_label) with the initial trigger
+  # payload as a fallback. This is authoritative location data straight from
+  # Frigate — far more reliable than letting the model guess where the subject
+  # was, and it keeps the AI from inventing areas it never actually entered.
+  - variables:
+      detected_zones: >-
+        {% set ns = namespace(zones=[]) %}
+        {% set init = trigger.payload_json['after'] %}
+        {% set ns.zones = ns.zones + (init['entered_zones'] or []) + (init['current_zones'] or []) %}
+        {% if event is defined and event is not none %}
+          {% set last = event['after'] %}
+          {% set ns.zones = ns.zones + (last['entered_zones'] or []) + (last['current_zones'] or []) %}
+        {% endif %}
+        {{ ns.zones | unique | list }}
+
   # ── Debug: pre-AI log ─────────────────────────────────────────────────────
   - alias: Debug pre-AI
     if:
@@ -642,6 +659,7 @@ actions:
               snapshot_url: {{ snapshot_url }}
               local_snapshot_path: {{ local_snapshot_path }}
               use_collage: {{ input_use_collage }}
+              detected_zones: {{ detected_zones }}
 
   # ── AI snapshot analysis ──────────────────────────────────────────────────
   - alias: 'AI: Analyse Frigate snapshot'
@@ -665,6 +683,10 @@ actions:
         {% if input_known_identities | trim != '' %}
           Known identities:
           {{ input_known_identities }}
+        {% endif %}
+        {% if detected_zones | length > 0 %}
+          Detected zones (authoritative location data):
+          The camera system tracked the {{ object }} in the following zone(s): {{ detected_zones | join(', ') }}. This is ground-truth location data and is more reliable than anything you infer visually. Only describe the subject as being in, entering, or moving through an area if it corresponds to one of these zones. Do not claim they approached, reached, or used any area that is not in this list.
         {% endif %}
         {% if input_sublabel and sub_label %}
           Identity information:


### PR DESCRIPTION
## What changed

Passes Frigate's detected zones into the `ai_task` prompt as authoritative location data, so the model stops inventing locations (e.g. "person going up/down the stairs" when someone merely walks past them). The zones come straight from the event MQTT payload — hard ground truth about where the subject actually was — which is far more reliable than the VLM's spatial guessing.

## How it works

1. **New `detected_zones` variable** (before the AI step) merges `entered_zones` + `current_zones` from:
   - the freshest event-loop payload (`event`, which persists after the loop the same way `sub_label` already does), and
   - the initial trigger payload as a fallback,

   then de-duplicates. `entered_zones` is cumulative over a Frigate event, so this captures every zone the subject passed through.

2. **New prompt section** injected into the `ai_task.generate_data` instructions (only when zones are present):

   > Detected zones (authoritative location data): The camera system tracked the `<object>` in the following zone(s): `<zones>`. This is ground-truth location data and is more reliable than anything you infer visually. Only describe the subject as being in, entering, or moving through an area if it corresponds to one of these zones. Do not claim they approached, reached, or used any area that is not in this list.

3. **Debug mode** now logs `detected_zones` in the pre-AI log line.

4. **README** gains a "Zone-grounded analysis" feature bullet.

Degrades gracefully: if an event has no zones, the section is skipped and behavior is unchanged. No new inputs or setup required — it uses data already present in every Frigate event message.

## Notes

- For best results the Frigate zones should be named meaningfully (e.g. `Walkway`, `Patio`, `Driveway`), since those names are what the AI is told to anchor on. Zone names complement the per-camera **Scene Context** field.
- Validated that the blueprint YAML still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LykB7Jh9iGHUGbRha4zyWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01LykB7Jh9iGHUGbRha4zyWa)_