### PR TITLE
Filter automation trigger by camera and label at the MQTT topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Then select `sensor.frigate_vision_history` as the **MQTT History Sensor Entity*
 | Section | Option | Description |
 |---|---|---|
 | — | Camera | Frigate camera entity to monitor |
-| — | Labels | Object types to notify on (person, dog, car, etc.) |
+| — | Label | Object type to notify on (person, dog, car, etc.) — the automation triggers only on this label |
 | — | Helper | `input_boolean` for AI job queuing |
 | — | Cooldown | Minimum time between notifications |
 | — | Mobile Device(s) | One or more devices to notify |

--- a/frigate_vision.yaml
+++ b/frigate_vision.yaml
@@ -44,13 +44,13 @@ blueprint:
           domain: [camera]
           multiple: false
 
-    labels:
-      name: Labels to Notify On
-      description: List of Frigate object labels to notify on. Leave empty to match all.
-      default: [person]
+    label:
+      name: Label to Notify On
+      description: The Frigate object label to notify on. The automation triggers only on this label.
+      default: person
       selector:
         select:
-          multiple: true
+          multiple: false
           options:
             - person
             - dog
@@ -344,13 +344,15 @@ blueprint:
 # ── Trigger ──────────────────────────────────────────────────────────────────
 trigger_variables:
   input_camera: !input camera
-  camera: '{{ input_camera | replace(''camera.'', '''') }}'
+  camera: '{{ input_camera | replace(''camera.'', '''') | lower | replace(''-'',''_'') }}'
+  input_label: !input label
+  label: '{{ input_label | lower }}'
 
 trigger:
   - topic: frigate/events
-    payload: '{{ camera }}/new'
+    payload: '{{ camera }}/new/{{ label }}'
     value_template: >-
-      {{ value_json['after']['camera'] | lower | replace('-','_') }}/{{ value_json['type'] }}
+      {{ value_json['after']['camera'] | lower | replace('-','_') }}/{{ value_json['type'] }}/{{ value_json['after']['label'] }}
     id: frigate-event
     trigger: mqtt
 
@@ -377,12 +379,11 @@ actions:
       input_ha_port: !input ha_port
       input_frigate_url: !input frigate_url
       input_frigate_port: !input frigate_port
-      input_labels: !input labels
+      input_label: !input label
       input_mqtt_history_topic: !input mqtt_history_topic
       input_mqtt_history_limit: !input mqtt_history_limit
       input_mqtt_broker_sensor: !input mqtt_broker_sensor
       input_use_collage: !input use_collage
-      labels: '{{ input_labels | list | lower }}'
       object: '{{ trigger.payload_json[''after''][''label''] }}'
       label: '{{ object | title }}'
       raw_device: !input notify_device
@@ -416,10 +417,6 @@ actions:
       local_snapshot_path: '/config/www/frigate/frigate_event_{{ camera }}_{{ id }}.jpg'
       update_thumbnail: true
       alert_once: true
-
-  # ── Label filter ─────────────────────────────────────────────────────────────
-  - condition: template
-    value_template: '{{ not labels | length or object in labels }}'
 
   # ── Initial notification (fast, before AI runs) ───────────────────────────
   - repeat:


### PR DESCRIPTION
## What changed

The automation used to trigger on **every** Frigate event for the selected camera, then a template condition (`object in labels`) cancelled the runs whose label didn't match. On a busy camera that produced a flood of cancelled traces — e.g. every `car` event firing and immediately aborting on a person-only automation.

This moves the label match up into the MQTT trigger itself, so the automation only ever fires for the configured label.

## Details

- **Trigger** now matches both camera **and** label at the topic level:
  - `payload: '{{ camera }}/new/{{ label }}'`
  - `value_template` renders the incoming event as `<camera>/<type>/<label>`
- **`trigger_variables`** gained `label` (lowercased from the input) and the `camera` variable is now normalized (`| lower | replace('-','_')`) so it matches the rendered Frigate topic — previously the camera side wasn't normalized, which could silently fail to match on cameras with capitals or dashes.
- **Input** `labels` (multi-select) → `label` (single-select). Multi-label support is dropped intentionally; one automation now targets one label.
- **Removed** the now-redundant label-filter condition and its dead `labels` variable — the trigger is the single source of truth.
- README option table updated (`Labels` → `Label`).

## Breaking change

Renaming the blueprint input `labels` → `label` means existing automations built on this blueprint will lose that input's value on update and must **re-select their label** once. No other inputs are affected.

## Validation

- Blueprint YAML parses cleanly.
- Grepped the file for any remaining `labels` / `input_labels` references — none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LykB7Jh9iGHUGbRha4zyWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01LykB7Jh9iGHUGbRha4zyWa)_