### PR TITLE
Tighten collage sampling window and move zones to end of AI prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ chmod +x /config/scripts/extract_frigate_frames.sh
 
 | Script | Purpose |
 |---|---|
-| `frigate_collage.sh` | Downloads the event clip, extracts 4 frames at 10/35/60/90% through the clip, and assembles them into a single-row (1×4) collage for AI analysis |
+| `frigate_collage.sh` | Downloads the event clip, extracts 4 frames at 20/40/60/80% through the clip, and assembles them into a single-row (1×4) collage for AI analysis |
 | `extract_frigate_frames.sh` | Lightweight alternative — extracts 3 frames directly from the remote clip URL without downloading it first. No collage is built; useful for custom workflows |
 
 The snapshot download command (`download_frigate_snapshot`) is always required. The collage script is only called when **Use Multi-Frame Collage** is enabled in the blueprint.

--- a/frigate_collage.sh
+++ b/frigate_collage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # frigate_collage.sh
 #
-# Downloads a Frigate event clip, extracts 4 frames at 10/35/60/90% through
+# Downloads a Frigate event clip, extracts 4 frames at 20/40/60/80% through
 # the clip, then assembles them into a single-row (1×4) collage saved to
 # /config/www/frigate/. Frames are left unlabelled — overlaying camera name
 # and timestamps on top of already-busy frames only makes the collage harder
@@ -59,11 +59,16 @@ if [ -z "$DURATION" ]; then
   exit 1
 fi
 
-# ── Timestamps at 10 / 35 / 60 / 90 % ────────────────────────────────────
-T1=$(awk "BEGIN {print $DURATION * 0.1}")
-T2=$(awk "BEGIN {print $DURATION * 0.35}")
+# ── Timestamps at 20 / 40 / 60 / 80 % ────────────────────────────────────
+# Sample the active middle of the clip rather than the very start/end. Frigate
+# clips include pre/post-capture buffer where the subject usually isn't in
+# frame yet or has already left, so 10%/90% frames often come out empty —
+# which wastes half the collage and makes the AI infer bogus arrivals and
+# departures. Keeping to 20–80% concentrates the frames on the actual event.
+T1=$(awk "BEGIN {print $DURATION * 0.2}")
+T2=$(awk "BEGIN {print $DURATION * 0.4}")
 T3=$(awk "BEGIN {print $DURATION * 0.6}")
-T4=$(awk "BEGIN {print $DURATION * 0.9}")
+T4=$(awk "BEGIN {print $DURATION * 0.8}")
 
 echo "Extracting frames at: $T1  $T2  $T3  $T4"
 

--- a/frigate_vision.yaml
+++ b/frigate_vision.yaml
@@ -692,15 +692,18 @@ actions:
           Known identities:
           {{ input_known_identities }}
         {% endif %}
-        {% if detected_zones | length > 0 %}
-          Detected zones (authoritative location data):
-          The camera system tracked the {{ object }} in these zone(s), and ONLY these: {{ detected_zones | join(', ') }}. This is the complete, authoritative record of everywhere the subject went, and it overrides anything you think you see. The subject did NOT enter, approach, reach, or use any place that is not in this list — even if that place is clearly visible in the image. Describe the event using only these zones; do not name any other location.
-        {% endif %}
         {% if input_sublabel and sub_label_names %}
           Identity information:
           "{{ sub_label_names }}" was identified in this footage by previous machine learning analysis; use the name(s) naturally in the summary instead of generic terms like "a person".
         {% endif %}
         {{ input_prompt }}
+        {# Detected zones go LAST so the model reads this authoritative
+           constraint immediately before answering (recency), where a small
+           model weights it most heavily. #}
+        {% if detected_zones | length > 0 %}
+          Detected zones (authoritative location data):
+          The camera system tracked the {{ object }} in these zone(s), and ONLY these: {{ detected_zones | join(', ') }}. This is the complete, authoritative record of everywhere the subject went, and it overrides anything you think you see. The subject did NOT enter, approach, reach, or use any place that is not in this list — even if that place is clearly visible in the image. Describe the event using only these zones; do not name any other location.
+        {% endif %}
       attachments:
         - media_content_id: >-
             media-source://media_source/local/frigate/frigate_event_{{ camera }}_{{ id }}.jpg


### PR DESCRIPTION
## What changed

Two accuracy improvements for the AI analysis.

### 1. Tighter collage sampling (20/40/60/80%)

`frigate_collage.sh` sampled frames at 10/35/60/90% of the clip. Because Frigate clips include pre/post-capture buffer, the 10% and 90% frames frequently landed **before the subject entered frame or after they left** — coming out empty. That wasted half the 4-frame collage and, worse, an empty→subject→subject→empty sequence reads as "arrived then departed," feeding the exact directional hallucinations we've been fighting.

Changed the sample points to **20/40/60/80%**, concentrating the frames on the active middle of the event.

### 2. Detected zones moved to the end of the prompt

The authoritative detected-zones block was sitting in the middle of the AI instructions, with the generic task prompt read last. Small models weight the most recent instruction most heavily (recency), so the zone constraint — the thing we most need obeyed — is now emitted **last, immediately before the model answers**.

New instruction order: night note → scene context → known identities → identity info → base prompt → **detected zones (last)**.

## Notes

- Updated the script header comment and the README script-table entry to reflect the new sampling percentages.
- Sampling percentages remain a reasonable heuristic, not exact — Frigate's buffer length varies per config — but 20–80% is far more robust against empty frames than 10–90%.

## Validation

- `bash -n frigate_collage.sh` passes.
- Blueprint YAML parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LykB7Jh9iGHUGbRha4zyWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01LykB7Jh9iGHUGbRha4zyWa)_